### PR TITLE
Add /checkUser endpoint

### DIFF
--- a/app.js
+++ b/app.js
@@ -73,6 +73,15 @@ app.post('/checkToken', function(req, res, next) {
   }, next);
 });
 
+app.post('/checkUser', function(req, res, next) {
+  let user = req.body.user;
+  let groups = req.body.groups;
+
+  model.checkUser(groups, user).then(function(decision) {
+    res.status(200).json({ok: decision});
+  }, next);
+});
+
 app.get('/listTokens', function(req, res, next) {
   // Returns all documents in db where user matches the
   // X-Remote-User header as an application/json array.

--- a/app.js
+++ b/app.js
@@ -33,7 +33,7 @@ app.post('/createToken', function(req, res, next) {
   // Generates a random 32 character string and enters it
   // into the db.
   // Returns the new document as an application/json body.
-  let user = 'an8@sanger.ac.uk'; //req.headers['X-Remote-User'];
+  let user = req.headers['x-remote-user'];
 
   model.createToken(user, creation_msg).then(function(response) {
     res.status(200).json(response);
@@ -45,7 +45,7 @@ app.post('/revokeToken', function(req, res, next) {
   // which is to be rejected. Updates the document in db so that
   // the 'status' field is set to 'revoked'.
   // Returns the updated document in  an application/json body.
-  let user = 'an8@sanger.ac.uk'; //req.headers['X-Remote-User'];
+  let user = req.headers['x-remote-user'];
   let token;
 
   try {
@@ -84,8 +84,8 @@ app.post('/checkUser', function(req, res, next) {
 
 app.get('/listTokens', function(req, res, next) {
   // Returns all documents in db where user matches the
-  // X-Remote-User header as an application/json array.
-  let user = 'an8@sanger.ac.uk';
+  // x-remote-user header as an application/json array.
+  let user = req.headers['x-remote-user'];
 
   model.listTokens(user).then(function(docs) {
     res.status(200).json(docs);

--- a/app.js
+++ b/app.js
@@ -14,10 +14,8 @@ const path = require('path');
 const bodyParser = require('body-parser');
 const express = require('express');
 
+const constants = require('./lib/constants');
 const model = require('./lib/model');
-
-const creation_msg = 'Created by owner via web interface';
-const revocation_msg = 'Revoked by owner via web interface';
 
 const port = opts.get('port');
 
@@ -33,9 +31,9 @@ app.post('/createToken', function(req, res, next) {
   // Generates a random 32 character string and enters it
   // into the db.
   // Returns the new document as an application/json body.
-  let user = req.headers['x-remote-user'];
+  let user = req.headers[constants.USER_ID_HEADER];
 
-  model.createToken(user, creation_msg).then(function(response) {
+  model.createToken(user, constants.WEB_TOKEN_CREATION_MSG).then(function(response) {
     res.status(200).json(response);
   }, next);
 });
@@ -45,7 +43,7 @@ app.post('/revokeToken', function(req, res, next) {
   // which is to be rejected. Updates the document in db so that
   // the 'status' field is set to 'revoked'.
   // Returns the updated document in  an application/json body.
-  let user = req.headers['x-remote-user'];
+  let user = req.headers[constants.USER_ID_HEADER];
   let token;
 
   try {
@@ -54,7 +52,7 @@ app.post('/revokeToken', function(req, res, next) {
     next(e);
   }
 
-  model.revokeToken(user, token, revocation_msg).then(function(row) {
+  model.revokeToken(user, token, constants.WEB_TOKEN_REVOCATION_MSG).then(function(row) {
     res.status(200).json(row);
   }, next);
 });
@@ -85,7 +83,7 @@ app.post('/checkUser', function(req, res, next) {
 app.get('/listTokens', function(req, res, next) {
   // Returns all documents in db where user matches the
   // x-remote-user header as an application/json array.
-  let user = req.headers['x-remote-user'];
+  let user = req.headers[constants.USER_ID_HEADER];
 
   model.listTokens(user).then(function(docs) {
     res.status(200).json(docs);
@@ -118,4 +116,3 @@ app.use(function(err, req, res, next) {
 
 app.listen(port);
 logger.info(`express started on port ${port}`);
-

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const WEB_TOKEN_CREATION_MSG   = 'Created by owner via web interface';
+const WEB_TOKEN_REVOCATION_MSG = 'Revoked by owner via web interface';
+
+const USER_ID_HEADER = 'x-remote-user';
+
+const TOKEN_STATUS_REVOKED = 'revoked';
+const TOKEN_STATUS_VALID   = 'valid';
+const TOKEN_DURATION       = 7;
+const TOKEN_DURATION_UNIT  = 'days';
+
+const COLLECTION_TOKENS = 'tokens';
+const COLLECTION_USERS  = 'users';
+
+module.exports = {
+  WEB_TOKEN_CREATION_MSG,
+  WEB_TOKEN_REVOCATION_MSG,
+  USER_ID_HEADER,
+  TOKEN_STATUS_REVOKED,
+  TOKEN_STATUS_VALID,
+  TOKEN_DURATION,
+  TOKEN_DURATION_UNIT,
+  COLLECTION_TOKENS,
+  COLLECTION_USERS,
+};

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,9 +1,6 @@
 'use strict';
 
-const messages = require('./messages.json').ERRORS;
-
-const WEB_TOKEN_CREATION_MSG   = 'Created by owner via web interface';
-const WEB_TOKEN_REVOCATION_MSG = 'Revoked by owner via web interface';
+const messages = require('./messages.json');
 
 const USER_ID_HEADER = 'x-remote-user';
 
@@ -16,10 +13,10 @@ const COLLECTION_TOKENS = 'tokens';
 const COLLECTION_USERS  = 'users';
 
 module.exports = {
-  UNEXPECTED_NUM_DOCS: messages.UNEXPECTED_NUM_DOCS,
-  USER_NOT_TOKEN_OWNER: messages.USER_NOT_TOKEN_OWNER,
-  WEB_TOKEN_CREATION_MSG,
-  WEB_TOKEN_REVOCATION_MSG,
+  UNEXPECTED_NUM_DOCS: messages.ERRORS.UNEXPECTED_NUM_DOCS,
+  USER_NOT_TOKEN_OWNER: messages.ERRORS.USER_NOT_TOKEN_OWNER,
+  WEB_TOKEN_CREATION_MSG: messages.WEB_TOKEN.CREATION_MSG,
+  WEB_TOKEN_REVOCATION_MSG: messages.WEB_TOKEN.REVOCATION_MSG,
   USER_ID_HEADER,
   TOKEN_STATUS_REVOKED,
   TOKEN_STATUS_VALID,

--- a/lib/messages.json
+++ b/lib/messages.json
@@ -2,5 +2,9 @@
   "ERRORS": {
     "UNEXPECTED_NUM_DOCS": "Unexpected number of documents containing this token",
     "USER_NOT_TOKEN_OWNER": "This user does not own this token"
+  },
+  "WEB_TOKEN": {
+    "CREATION_MSG": "Created by owner via web interface",
+    "REVOCATION_MSG": "Revoked by owner via web interface"
   }
 }

--- a/lib/model.js
+++ b/lib/model.js
@@ -16,13 +16,9 @@ const randomBytes = require('crypto').randomBytes;
 const moment = require('moment');
 const MongoClient = require('mongodb').MongoClient;
 
-const config = require('./config.js');
-const logger = require('./logger.js');
-
-const TOKEN_STATUS_REVOKED = 'revoked';
-const TOKEN_STATUS_VALID   = 'valid';
-const TOKEN_DURATION       = 7;
-const TOKEN_DURATION_UNIT  = 'days';
+const constants = require('./constants.js');
+const config    = require('./config.js');
+const logger    = require('./logger.js');
 
 class DbError extends Error {
   constructor(message) {
@@ -69,7 +65,7 @@ p_db.catch(function(reason) {
   throw reason;
 });
 
-let p_collection = p_db.then(getCollection('tokens'));
+let p_collection = p_db.then(getCollection(constants.COLLECTION_TOKENS));
 
 p_collection.catch(function(reason) {
   logger.error(reason);
@@ -148,11 +144,11 @@ let createToken = function createToken(user, justification) {
   return generateTokenPromise().then(function(token) {
     let now = moment();
     let validDuration = moment.duration(
-      TOKEN_DURATION, TOKEN_DURATION_UNIT
+      constants.TOKEN_DURATION, constants.TOKEN_DURATION_UNIT
     );
     let doc = {
       token: token,
-      status: TOKEN_STATUS_VALID,
+      status: constants.TOKEN_STATUS_VALID,
       issueTime: now.format(),
       creationReason: justification,
       user: user,
@@ -210,12 +206,12 @@ let revokeToken = function revokeToken(user, token, justification) {
       return p_collection.then(function(collection) {
         return collection.updateOne({token: token},
           {$set: {
-            status: TOKEN_STATUS_REVOKED,
+            status: constants.TOKEN_STATUS_REVOKED,
             revocationReason: justification,
             revocationTime: moment().format()
           }})
           .then(function() {
-            doc.status = TOKEN_STATUS_REVOKED;
+            doc.status = constants.TOKEN_STATUS_REVOKED;
             return doc;
           });
       });
@@ -249,7 +245,7 @@ let checkUser = function checkUser(groups, user) {
     return Promise.reject(new Error('checkUser: undefined argument(s)'));
   }
 
-  let p_user_collection = p_db.then(getCollection('users'));
+  let p_user_collection = p_db.then(getCollection(constants.COLLECTION_USERS));
 
   let p_user_cursor = p_user_collection.then(function(collection) {
     return collection.find({user: user});
@@ -297,8 +293,6 @@ let checkToken = function checkToken(groups, token) {
 };
 
 module.exports = {
-  TOKEN_STATUS_VALID,
-  TOKEN_STATUS_REVOKED,
   DbError,
   createToken,
   revokeToken,

--- a/lib/model.js
+++ b/lib/model.js
@@ -244,32 +244,15 @@ let listTokens = function listTokens(user) {
 };
 
 
-let checkToken = function checkToken(groups, token) {
-  if (! groups instanceof Array || typeof token !== 'string') {
-    return Promise.reject(new Error('checkToken: undefined argument(s)'));
+let checkUser = function checkUser(groups, user) {
+  if (! groups instanceof Array || typeof user !== 'string') {
+    return Promise.reject(new Error('checkUser: undefined argument(s)'));
   }
-  let p_cursor = findMatchingTokens(token, 'valid');
-
-  let p_onlyOneDoc = cursorHasExactlyOneDoc(p_cursor);
-
-  let p_document = p_onlyOneDoc.then(getDocument(p_cursor));
-
-  let p_user = p_document.then(function(doc) {
-    return doc.user;
-  });
 
   let p_user_collection = p_db.then(getCollection('users'));
 
-  let p_user_cursor = p_user.then(function(user) {
-    return p_user_collection.then(function(collection) {
-      return new Promise(function(resolve, reject) {
-        try {
-          resolve(collection.find({user: user}));
-        } catch (e) {
-          reject(e);
-        }
-      });
-    });
+  let p_user_cursor = p_user_collection.then(function(collection) {
+    return collection.find({user: user});
   });
 
   let p_user_onlyOneDoc = cursorHasExactlyOneDoc(p_user_cursor);
@@ -281,24 +264,35 @@ let checkToken = function checkToken(groups, token) {
   });
 
   return p_groups.then(function(userGroups) {
-    return p_document.then(function(doc) {
-      // EVERY member of 'groups' (the groups that the ranger server
-      // claims have access to the files) should appear in userGroups
-      if (!userGroups) {
-        return false;
-      }
-      if (doc.status === 'revoked') {
-        return false;
-      }
-
-      let now = moment();
-      if (doc.expiryTime && now.isAfter(doc.expiryTime)) {
-        return false;
-      }
-      return groups.every(function(val) {
-        return userGroups.indexOf(val) >= 0;
-      });
+    if (!userGroups) {
+      return false;
+    }
+    return groups.every(function(val) {
+      return userGroups.indexOf(val) >= 0;
     });
+  })
+}
+
+
+let checkToken = function checkToken(groups, token) {
+  if (! groups instanceof Array || typeof token !== 'string') {
+    return Promise.reject(new Error('checkToken: undefined argument(s)'));
+  }
+  let p_cursor = findMatchingTokens(token, 'valid');
+
+  let p_onlyOneDoc = cursorHasExactlyOneDoc(p_cursor);
+
+  let p_document = p_onlyOneDoc.then(getDocument(p_cursor));
+
+  return p_document.then(function(doc) {
+    if (doc.status === 'revoked') {
+      return false;
+    }
+    let now = moment();
+    if (doc.expiryTime && now.isAfter(doc.expiryTime)) {
+      return false;
+    }
+    return checkUser(groups, doc.user);
   });
 };
 
@@ -309,5 +303,6 @@ module.exports = {
   createToken,
   revokeToken,
   listTokens,
-  checkToken
+  checkUser,
+  checkToken,
 };

--- a/public/js/auth.js
+++ b/public/js/auth.js
@@ -57,7 +57,7 @@ define(['jquery', 'clipboard'], function($, Clipboard) {
     };
 
     $.post({
-      url: '/revokeToken',
+      url: 'revokeToken',
       data: JSON.stringify({token: token}),
       success: revokeSuccess,
       contentType: 'application/json',
@@ -94,7 +94,7 @@ define(['jquery', 'clipboard'], function($, Clipboard) {
     });
 
     $('#create-token-button').on('click', function() {
-      $.post('/createToken', function(data, status) {
+      $.post('createToken', function(data, status) {
         if (status === 'success') {
           var $th = $('#table-headers');
           var $row = generateTokenRow($('<tr></tr>'), data);
@@ -105,7 +105,7 @@ define(['jquery', 'clipboard'], function($, Clipboard) {
       });
     });
 
-    $.get('/listTokens', function(data, status) {
+    $.get('listTokens', function(data, status) {
       if (status === 'success') {
         var $table = $('#token-table');
         data.forEach(function(doc) {

--- a/public/js/auth.js
+++ b/public/js/auth.js
@@ -65,7 +65,7 @@ define(['jquery', 'clipboard'], function($, Clipboard) {
     };
 
     $.post({
-      url: '/revokeToken',
+      url: 'revokeToken',
       data: JSON.stringify({token: token}),
       success: revokeSuccess,
       contentType: 'application/json',
@@ -107,7 +107,7 @@ define(['jquery', 'clipboard'], function($, Clipboard) {
 
     $('#create-token-button').on('click', function() {
       $.post({
-        url: '/createToken',
+        url: 'createToken',
         success: function(data) {
           var $th = $('#table-headers');
           var $row = generateTokenRow($('<tr></tr>'), data);
@@ -121,7 +121,7 @@ define(['jquery', 'clipboard'], function($, Clipboard) {
     });
 
     $.get({
-      url: '/listTokens',
+      url: 'listTokens',
       success: function(data) {
         var $table = $('#token-table');
         data.forEach(function(doc) {

--- a/test/client/test.js
+++ b/test/client/test.js
@@ -51,7 +51,7 @@ requirejs(['qunit', 'jquery', 'auth'], function(QUnit, $, auth) {
       ];
 
       $.get = function mockAjax(opts) {
-        assert.strictEqual(opts.url, '/listTokens',
+        assert.strictEqual(opts.url, 'listTokens',
           'Makes request to /listTokens');
         opts.success(data, 'success');
 
@@ -163,14 +163,14 @@ requirejs(['qunit', 'jquery', 'auth'], function(QUnit, $, auth) {
         },
       ];
       $.get = function mockAjaxGet(opts) {
-        assert.strictEqual(opts.url, '/listTokens', 'Makes request to /listTokens');
+        assert.strictEqual(opts.url, 'listTokens', 'Makes request to /listTokens');
         opts.success(data, 'success');
       };
       auth.setupPage();
 
       var oldAjaxPost = $.post;
       $.post = function mockAjaxPost(opts) {
-        assert.strictEqual(opts.url, '/revokeToken',
+        assert.strictEqual(opts.url, 'revokeToken',
           'Makes POST request to /revokeToken');
         assert.strictEqual(opts.data, JSON.stringify({token: 'abc'}),
           'POST request data is JSON containing token to revoke');
@@ -203,7 +203,7 @@ requirejs(['qunit', 'jquery', 'auth'], function(QUnit, $, auth) {
         opts.success([], 'success');
       };
       $.post = function mockAjaxPost(opts) {
-        assert.strictEqual(opts.url, '/createToken',
+        assert.strictEqual(opts.url, 'createToken',
           'Makes POST request to /createToken');
         assert.strictEqual(
           $('#token-table').children('tbody').children('tr').length, 1,

--- a/test/client/test.js
+++ b/test/client/test.js
@@ -45,8 +45,8 @@ requirejs(['qunit', 'jquery', 'auth'], function(QUnit, $, auth) {
         }
       ];
       $.get = function mockAjax(url, cback) {
-        assert.strictEqual(url, '/listTokens',
-          'Makes request to /listTokens');
+        assert.strictEqual(url, 'listTokens',
+          'Makes request to listTokens');
         cback(data, 'success');
         assert.strictEqual(
           $('#token-table').children('tbody').children('tr').length, 2,

--- a/test/server/model.spec.js
+++ b/test/server/model.spec.js
@@ -7,6 +7,7 @@ const MongoClient = require('mongodb').MongoClient;
 const fse = require('fs-extra');
 const tmp = require('tmp');
 
+const constants = require('../../lib/constants');
 const config = require('../../lib/config');
 config.provide(() => {return {mongourl: 'mongodb://localhost:27017/test'};});
 const model = require('../../lib/model');
@@ -97,7 +98,7 @@ describe('exported function', function() {
       let user = 'user@example.com';
       let p_insert = model.createToken(user, 'test creation');
 
-      let p_collection = p_db.then(getCollection('tokens'));
+      let p_collection = p_db.then(getCollection(constants.COLLECTION_TOKENS));
 
       let p_cursor = p_collection.then(function(collection) {
         return p_insert.then(function() {
@@ -129,7 +130,7 @@ describe('exported function', function() {
       let p_docExpectation = p_doc.then(function(doc) {
         expect(doc.user).toBe(user);
         expect(doc.token).toMatch(/^[a-zA-Z0-9_-]{32}$/gm);
-        expect(doc.status).toBe(model.TOKEN_STATUS_VALID);
+        expect(doc.status).toBe(constants.TOKEN_STATUS_VALID);
         expect(moment(doc.issueTime).isValid()).toBe(true);
         expect(doc.creationReason).toBe('test creation');
         expect(moment(doc.expiryTime).isValid()).toBe(true);
@@ -172,11 +173,11 @@ describe('exported function', function() {
       let user = 'user@example.com';
       let token = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
 
-      let p_collection = p_db.then(getCollection('tokens'));
+      let p_collection = p_db.then(getCollection(constants.COLLECTION_TOKENS));
 
       let p_insertion = p_collection.then(function(collection) {
         return collection.insertOne({
-          user, token, status: model.TOKEN_STATUS_VALID
+          user, token, status: constants.TOKEN_STATUS_VALID
         });
       });
 
@@ -197,7 +198,7 @@ describe('exported function', function() {
       p_doc.then(function(doc) {
         expect(doc.user).toBe(user);
         expect(doc.token).toBe(token);
-        expect(doc.status).toBe(model.TOKEN_STATUS_REVOKED);
+        expect(doc.status).toBe(constants.TOKEN_STATUS_REVOKED);
       }, function(reason) {
         fail(reason);
       }).then(done);
@@ -240,11 +241,11 @@ describe('exported function', function() {
       let revokingUser = 'bad@example.com';
       let token = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
 
-      let p_collection = p_db.then(getCollection('tokens'));
+      let p_collection = p_db.then(getCollection(constants.COLLECTION_TOKENS));
 
       let p_insertion = p_collection.then(function(collection) {
         return collection.insertOne({
-          creatingUser, token, status: model.TOKEN_STATUS_VALID
+          creatingUser, token, status: constants.TOKEN_STATUS_VALID
         });
       });
 
@@ -265,7 +266,7 @@ describe('exported function', function() {
       let user = 'user@example.com';
       let token = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
 
-      let p_collection = p_db.then(getCollection('tokens'));
+      let p_collection = p_db.then(getCollection(constants.COLLECTION_TOKENS));
 
       let p_revoke = p_collection.then(function() {
         return model.revokeToken(user, token, 'Test revocation');
@@ -300,17 +301,17 @@ describe('exported function', function() {
       let token1 = 'BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB';
       let token2 = 'CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC';
 
-      let p_collection = p_db.then(getCollection('tokens'));
+      let p_collection = p_db.then(getCollection(constants.COLLECTION_TOKENS));
 
       let p_insertion1 = p_collection.then(function(collection) {
         return collection.insertOne({
-          user, token: token1, status: model.TOKEN_STATUS_VALID
+          user, token: token1, status: constants.TOKEN_STATUS_VALID
         });
       });
 
       let p_insertion2 = p_collection.then(function(collection) {
         return collection.insertOne({
-          user, token: token2, status: model.TOKEN_STATUS_VALID
+          user, token: token2, status: constants.TOKEN_STATUS_VALID
         });
       });
 
@@ -330,7 +331,7 @@ describe('exported function', function() {
         });
         expect(tokenUsers).toBe(true);
         let tokensValid = tokens.every(function(row) {
-          return row.status === model.TOKEN_STATUS_VALID;
+          return row.status === constants.TOKEN_STATUS_VALID;
         });
         expect(tokensValid).toBe(true);
       }, function(reason) {
@@ -341,7 +342,7 @@ describe('exported function', function() {
     it('succeeds despite no tokens', function(done) {
       let user = 'user@example.com';
 
-      let p_collection = p_db.then(getCollection('tokens'));
+      let p_collection = p_db.then(getCollection(constants.COLLECTION_TOKENS));
 
       let p_noTokens = p_collection.then(function() {
         return model.listTokens(user);
@@ -376,15 +377,15 @@ describe('exported function', function() {
       let token = 'DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD';
       let reqdGroups = ['1', '5'];
 
-      let p_tokenCollection = p_db.then(getCollection('tokens'));
+      let p_tokenCollection = p_db.then(getCollection(constants.COLLECTION_TOKENS));
 
       let p_tokenInsertion = p_tokenCollection.then(function(collection) {
         return collection.insertOne({
-          user, token, status: model.TOKEN_STATUS_VALID
+          user, token, status: constants.TOKEN_STATUS_VALID
         });
       });
 
-      let p_userCollection = p_db.then(getCollection('users'));
+      let p_userCollection = p_db.then(getCollection(constants.COLLECTION_USERS));
 
       let p_userInsertion = p_userCollection.then(function(collection) {
         return collection.insertOne({user, groups: ['1', '2', '5']});
@@ -407,15 +408,15 @@ describe('exported function', function() {
       let token = 'DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD';
       let reqdGroups = ['1', '5'];
 
-      let p_tokenCollection = p_db.then(getCollection('tokens'));
+      let p_tokenCollection = p_db.then(getCollection(constants.COLLECTION_TOKENS));
 
       let p_tokenInsertion = p_tokenCollection.then(function(collection) {
         return collection.insertOne({
-          user, token, status: model.TOKEN_STATUS_VALID
+          user, token, status: constants.TOKEN_STATUS_VALID
         });
       });
 
-      let p_userCollection = p_db.then(getCollection('users'));
+      let p_userCollection = p_db.then(getCollection(constants.COLLECTION_USERS));
 
       let p_userInsertion = p_userCollection.then(function(collection) {
         return collection.insertOne({user, groups: ['1', '2', '3']});
@@ -440,7 +441,7 @@ describe('exported function', function() {
       let token = 'DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD';
       let reqdGroups = ['1', '5'];
 
-      let p_userCollection = p_db.then(getCollection('users'));
+      let p_userCollection = p_db.then(getCollection(constants.COLLECTION_USERS));
 
       let p_userInsertion = p_userCollection.then(function(collection) {
         return collection.insertOne({user, groups: ['1', '2', '3']});


### PR DESCRIPTION
Adds the `/checkUser` endpoint to provide authorisation for the `authuser` authorisation style in npg_ranger.

Also changes to use 'X-Remote-User' header to find the user, instead of being hardcoded to my email!

Uses https://github.com/wtsi-npg/npg_ranger/pull/166