### PR TITLE
Server test listtoken

### DIFF
--- a/lib/authorisation_controller.js
+++ b/lib/authorisation_controller.js
@@ -40,11 +40,11 @@ module.exports.setup = function( app ) {
 
     try {
       // If content-type header is not set (or set to something not
-      // application/json, req.body will be undefined, so trying to access
+      // application/json), req.body will be undefined, so trying to access
       // req.body.token will throw an error.
+      assert(req.body, 'Request is missing a body');
+      assert(req.body.token, 'Request body is missing a token entry');
       token = req.body.token;
-      // If content-type header is set, but body is missing
-      assert(token);
     } catch (e) {
       // 400 error because input was malformed
       e.statusCode = 400;

--- a/lib/authorisation_controller.js
+++ b/lib/authorisation_controller.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const assert    = require('assert');
+
 const constants = require('./constants');
 const model     = require('./model');
 
@@ -37,9 +39,16 @@ module.exports.setup = function( app ) {
     let token;
 
     try {
+      // If content-type header is not set (or set to something not
+      // application/json, req.body will be undefined, so trying to access
+      // req.body.token will throw an error.
       token = req.body.token;
+      // If content-type header is set, but body is missing
+      assert(token);
     } catch (e) {
-      next(e);
+      // 400 error because input was malformed
+      e.statusCode = 400;
+      return next(e);
     }
 
     model.revokeToken(

--- a/test/server/server.spec.js
+++ b/test/server/server.spec.js
@@ -13,7 +13,7 @@ const tmp         = require('tmp');
 let config    = require('../../lib/config');
 let constants = require('../../lib/constants');
 
-let utils     = require('./test_utils');
+const utils     = require('./test_utils');
 
 let BASE_PORT   = 9000;
 let PORT_RANGE  = 200;
@@ -288,6 +288,24 @@ describe('server', () => {
             "content-type": 'application/json',
             "x-remote-user": 'someuser@domain.com'
           },
+        }, (err, res, body) => {
+          if(err){
+            done.fail(err);
+          }
+          expect(res.statusCode).toBe(400);
+          expect(body).toMatch(http.STATUS_CODES[400]);
+          done();
+        });
+      });
+
+      it('test revoke returns error when missing token in json', (done) => {
+        request.post({
+          url: `http://localhost:${SERVER_PORT}/revokeToken`,
+          headers: {
+            "content-type": 'application/json',
+            "x-remote-user": 'someuser@domain.com'
+          },
+          body: '{"someothervalue": "1"}'
         }, (err, res, body) => {
           if(err){
             done.fail(err);

--- a/test/server/server.spec.js
+++ b/test/server/server.spec.js
@@ -264,6 +264,40 @@ describe('server', () => {
         }, done.fail);
       });
 
+      it('test revoke returns error when content-type not set', (done) => {
+        request.post({
+          url: `http://localhost:${SERVER_PORT}/revokeToken`,
+          headers: {
+            "x-remote-user": 'someuser@domain.com'
+          },
+          body: '{"token": "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"}'
+        }, (err, res, body) => {
+          if(err){
+            done.fail(err);
+          }
+          expect(res.statusCode).toBe(400);
+          expect(body).toMatch(http.STATUS_CODES[400]);
+          done();
+        });
+      });
+
+      it('test revoke returns error when body is missing', (done) => {
+        request.post({
+          url: `http://localhost:${SERVER_PORT}/revokeToken`,
+          headers: {
+            "content-type": 'application/json',
+            "x-remote-user": 'someuser@domain.com'
+          },
+        }, (err, res, body) => {
+          if(err){
+            done.fail(err);
+          }
+          expect(res.statusCode).toBe(400);
+          expect(body).toMatch(http.STATUS_CODES[400]);
+          done();
+        });
+      });
+
       it('test revoke returns error when non json req', (done) => {
         request.post({
           url: `http://localhost:${SERVER_PORT}/revokeToken`,

--- a/test/server/server.spec.js
+++ b/test/server/server.spec.js
@@ -174,6 +174,51 @@ describe('server', () => {
         done();
       });
 
+      it('creates a token and lists it', function (done) {
+        let token;
+        let groups = ['1', '2', '3'];
+        let user = 'someuser@domain.com';
+        insertUser(p_db, user, groups).then(function() {
+          request.post({
+            url: `http://localhost:${SERVER_PORT}/createToken`,
+            headers: {
+              "content-type": 'application/json',
+              "x-remote-user": user
+            },
+          }, (err, res, body) => {
+              if(err){
+                done.fail(err);
+              }
+
+              expect(res.statusCode).toBe(200);
+              console.log(body);
+              let jbody = JSON.parse(body);
+
+              expect(jbody.token).toBeDefined();
+              expect(jbody.user).toBe(user);
+              token = jbody.token;
+
+              request.get({
+                url: `http://localhost:${SERVER_PORT}/listTokens`,
+                headers: {
+                  "x-remote-user": user
+                },
+              }, (err2, res2, body2) => {
+                  if(err2){
+                    done.fail(err2);
+                  }
+                  expect(res2.statusCode).toBe(200);
+                  let jbody2 = JSON.parse(body2);
+                  expect(jbody2.length).toBe(1);
+                  expect(jbody2[0].token).toBe(token);
+                  expect(jbody2[0].status).toBe(constants.TOKEN_STATUS_VALID);
+                  expect(jbody2[0].user).toBe(user);
+                  done();
+              });
+          });
+        }, done.fail);
+      });
+
       it('creates a token and validates it', function (done) {
         let postData = {
           "groups": [ '1', '2', '3' ]


### PR DESCRIPTION
Add a test case for /listTokens and test cases for /revokeToken where json input is incorrect.

Incorrect JSON (missing content-type, missing body (malformed body is caught in bodyParser middleware)) for /revokeToken now always causes a 400 response.

Boosts lib/authorisation_controller.js coverage to 100%! :tada: